### PR TITLE
[LF-327] Add new date filter for ads

### DIFF
--- a/scripts/widget.js
+++ b/scripts/widget.js
@@ -9,27 +9,28 @@ var type = getUrlParameter('type') || 'standard',
     customCss = '',
     adcentric = getUrlParameter('adcentric') || 'false',
     defaultView = (adcentric === 'true') ? 'ads' : 'businesses',
-    featuredLevelDisplay = (minFeaturedLevel == '0') ? 'None' : 'Level ' + minFeaturedLevel;
+    featuredLevelDisplay = (minFeaturedLevel == '0') ? 'None' : 'Level ' + minFeaturedLevel,
+    adStartDate = getUrlParameter('days_ago') || '30';
 
 function updateBrowserURL() {
   var publisherOrPartner = (type === 'secure') ? '&partner=' + partner : '&publisher=' + publisher;
-  window.history.replaceState(null, null, '?type=' + type + publisherOrPartner + '&width=' + width + '&height=' + height + '&adcentric=' + adcentric + '&min-featured-level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory);
+  window.history.replaceState(null, null, '?type=' + type + publisherOrPartner + '&width=' + width + '&height=' + height + '&adcentric=' + adcentric + '&min-featured-level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&days_ago=' + adStartDate);
 };
 
 function updateIframeSrc() {
-  $('.ownlocal-widget.standard iframe').attr('src', 'http://' + publisher + '/embed?adcentric=' + adcentric + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&custom_css=' + customCss);
+  $('.ownlocal-widget.standard iframe').attr('src', 'http://' + publisher + '/embed?adcentric=' + adcentric + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&custom_css=' + customCss + '&days_ago=' + adStartDate);
 };
 
 function updateSecureIframeSrc() {
-  $('.ownlocal-widget.secure iframe').attr('src', 'https://widget.secure.ownlocal.com/embed/' + partner + '?adcentric=' + adcentric + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&custom_css=' + customCss);
+  $('.ownlocal-widget.secure iframe').attr('src', 'https://widget.secure.ownlocal.com/embed/' + partner + '?adcentric=' + adcentric + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&custom_css=' + customCss + '&days_ago=' + adStartDate);
 };
 
 function updateEmbedCode() {
-  $('.code').html('&lt;var id="ownlocal"&gt;&lt;script id="ownlocal-script" data-active="' + defaultView + '" src="http://' + publisher + '/embed.js?h=' + height + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '"&gt;&lt;/script&gt;&lt;/var&gt;');
+  $('.code').html('&lt;var id="ownlocal"&gt;&lt;script id="ownlocal-script" data-active="' + defaultView + '" src="http://' + publisher + '/embed.js?h=' + height + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&days_ago=' + adStartDate + '"&gt;&lt;/script&gt;&lt;/var&gt;');
 };
 
 function updateSecureEmbedCode() {
-  $('.code.secure').html('&lt;var id="ownlocal"&gt;&lt;script async id="ownlocal-script" data-active="' + defaultView + '" src="https://widget.secure.ownlocal.com/embed.js?uuid=' + partner  + '&?h=' + height + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '"&gt;&lt;/script&gt;&lt;/var&gt;');
+  $('.code.secure').html('&lt;var id="ownlocal"&gt;&lt;script async id="ownlocal-script" data-active="' + defaultView + '" src="https://widget.secure.ownlocal.com/embed.js?uuid=' + partner  + '&?h=' + height + '&min_featured_level=' + minFeaturedLevel + '&category=' + category + '&subcategory=' + subcategory + '&days_ago=' + adStartDate + '"&gt;&lt;/script&gt;&lt;/var&gt;');
 };
 
 function updateAllSrcAndUrls() {
@@ -84,6 +85,14 @@ $(document).ready(function() {
   // set minimum featured level display
   $('#min-featured-level .selection').html(featuredLevelDisplay);
   $('.min-featured-level-' + minFeaturedLevel + '-button').addClass('active');
+
+  // set minimum featured level display
+  $('#min-featured-level .selection').html(featuredLevelDisplay);
+  $('.min-featured-level-' + minFeaturedLevel + '-button').addClass('active');
+
+  // set ad start date display
+  $('#ad-start-date .selection').html("All active ads");
+  $(adStartDate + '-days-ago-button').addClass('active');
 
   $('.dropdown').on('click', function(){
     $(this).toggleClass('active');
@@ -171,6 +180,13 @@ $(document).ready(function() {
     $('.dropdown.default-view-dropdown .button').not(this).removeClass('active');
     updateAllSrcAndUrls();
   });
+
+  $('.ad-start-date').on('click', function() {
+    adStartDate = this.dataset.selection;
+    $('#ad-start-date .selection').html(this.dataset.display);
+    $('.dropdown.ad-start-date-dropdown .button').not(this).removeClass('active');
+    updateAllSrcAndUrls();
+  })
 
   $('.min-featured-level').on('click', function() {
     minFeaturedLevel = this.dataset.featured;

--- a/widget.html
+++ b/widget.html
@@ -90,6 +90,18 @@ title: Platform Widget
     </div>
 
     <div class="block">
+      <div class="label">Filter Ad Start Date</div>
+      <div id="ad-start-date" class="dropdown ad-start-date-dropdown">
+        <div class="selection"></div>
+        <ul class="sizes">
+          <li data-selection="30" data-display="All active ads" class="button 30-days-ago-button ad-start-date">All active ads</li>
+          <li data-selection="7" data-display="Active ads from last 7 days" class="button 7-days-ago-button ad-start-date">Active ads from last 7 days</li>
+          <li data-selection="1" data-display="Active ads from last 24 hours" class="button 1-days-ago-button ad-start-date">Active ads from last 24 hours</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="block">
       <div class="label">Filter Categories</div>
       <div class="input-wrapper">
         <input id="category" type="text" placeholder="real-estate,restaurants">


### PR DESCRIPTION
https://ownlocal.atlassian.net/browse/LF-327

Adds a dropdown menu with options for ad start date filtering; updates the embed code below the widget. (Depends on changes from https://github.com/OwnLocal/LocalFusion/pull/427).

Also refactors the widget filtering selections.

![screen shot 2017-01-31 at 12 13 52 pm](https://cloud.githubusercontent.com/assets/8560084/22479488/964dd342-e7b3-11e6-89b5-6fa22ada51d4.png)

![screen shot 2017-01-31 at 12 14 10 pm](https://cloud.githubusercontent.com/assets/8560084/22479496/9b79aaa8-e7b3-11e6-9e47-9fc95aab3b56.png)

![screen shot 2017-01-31 at 12 14 40 pm](https://cloud.githubusercontent.com/assets/8560084/22479516/a15371c0-e7b3-11e6-90c9-95019de7bbe6.png)
